### PR TITLE
Add MAX and MIN macro assumption comment

### DIFF
--- a/apu.c
+++ b/apu.c
@@ -19,8 +19,9 @@
 #define AUDIO_MEM_SIZE (0xFF3F - 0xFF10 + 1)
 #define AUDIO_ADDR_COMPENSATION 0xFF10
 
-#define MAX(a, b) (a > b ? a : b)
-#define MIN(a, b) (a <= b ? a : b)
+/* Assume neither a nor b is a statement expression of increment, decrement, or assignment */
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define MIN(a, b) ((a) <= (b) ? (a) : (b))
 
 /* Memory holding audio registers between 0xFF10 and 0xFF3F inclusive */
 static uint8_t audio_mem[AUDIO_MEM_SIZE];

--- a/gameboy.h
+++ b/gameboy.h
@@ -149,6 +149,7 @@
 #define ROM_HEADER_CHECKSUM_LOC 0x014D
 
 #ifndef MIN
+/* Assume neither a nor b is a statement expression of increment, decrement, or assignment */
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #endif
 


### PR DESCRIPTION
This add the assumption comment for properly using the simplified `MAX` and `MIN` macros (without dealing with the double evaluation problem).